### PR TITLE
Fix duplicate word in bio line

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,7 +58,7 @@ plugins:
 author:
   name   : "Benoit Fauve"
   avatar : "/assets/images/Dolly_the_sheep_headphones_2.jpg"
-  bio    : "ML, Speech and and more if it hits it off ."
+  bio    : "ML, Speech and more if it hits it off ."
   links:
     - label: "Website"
       icon: "fas fa-fw fa-link"


### PR DESCRIPTION
## Summary
- remove a duplicated "and" in `_config.yml` bio line

## Testing
- `grep -n "bio" -n _config.yml`

------
https://chatgpt.com/codex/tasks/task_e_6842f0a62ee88333b3b1fb1ce4f59889