### PR TITLE
Fix duplicate gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
-gem "jekyll-include-cache", group: :jekyll_plugins
 
 gem "tzinfo-data"
 gem "wdm", "~> 0.1.0" if Gem.win_platform?


### PR DESCRIPTION
## Summary
- remove duplicate `jekyll-include-cache` entry

## Testing
- `bundle install --path vendor/bundle` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6842ef76e90483338ab38ce5e5e5f143